### PR TITLE
Fixed issue:Typo and Placeholder Tag in login/signup pages

### DIFF
--- a/login.html
+++ b/login.html
@@ -114,7 +114,7 @@
         <h2>Login</h2>
         <form id="form" action="./discussion-forum.html" method="GET">
           <label for="username">Username:</label>
-          <input type="text" id="username" name="username" required />
+          <input type="text" id="username" name="username" required placeholder="Usename"/>
 
           <label for="password">Password:</label>
           <input type="password" id="password" name="password" required />
@@ -123,7 +123,7 @@
 
           <button>Login</button>
 
-          <div class="signup">Don't hava an account ? <a class="signup-link" href="./signup.html">Signup</a></div>
+          <div class="signup">Don't have an account ? <a class="signup-link" href="./signup.html">Signup</a></div>
           <!-- Change the button type to "submit" -->
         </form>
       </div>

--- a/signup.html
+++ b/signup.html
@@ -91,6 +91,8 @@
         button {
           margin-left: 90px;
         }
+       
+
       }
     </style>
   </head>
@@ -100,16 +102,16 @@
         <h2>Sign Up</h2>
         <form id="form" action="./discussion-forum.html" method="GET">
           <label for="username">Username:</label>
-          <input type="text" id="username" name="username" required />
+          <input type="text" id="username" name="username" required placeholder="Username"/>
 
           <label for="email">Email:</label>
-          <input type="email" id="email" name="email" required />
+          <input type="email" id="email" name="email" required placeholder="abc@gmail.com"/>
 
           <label for="password">Password:</label>
           <input type="password" id="password" name="password" required />
 
-          <button onclick="saveUsername()">Sign Up</button>
-          <div class="login">Already hava an account? <a class="login-link" href="./login.html">Login</a></div>
+          <button id="hover_button" onclick="saveUsername()">Sign Up</button>
+          <div class="login">Already have an account? <a class="login-link" href="./login.html">Login</a></div>
         </form>
       </div>
       <p style="text-align: center">&copy; All rights reserved 2023</p>


### PR DESCRIPTION
Typo error and placeholder tag in the login/sigup pages was updated.
<img width="531" alt="Screenshot 2024-10-07 at 1 19 41 AM" src="https://github.com/user-attachments/assets/181d5746-34a8-4f28-9dd2-739fb8d5fd95">
<img width="537" alt="Screenshot 2024-10-07 at 1 20 05 AM" src="https://github.com/user-attachments/assets/ddef32a6-2d30-4280-ad36-cb9b932532f0">
