### PR TITLE
Improved the audio controls on mantra-audio page

### DIFF
--- a/morning-mantra-audio.html
+++ b/morning-mantra-audio.html
@@ -23,8 +23,8 @@
       }
       .scroll-top-btn {
         position: fixed; /* Fixed position */
-        bottom: 30px; 
-        right: 30px; 
+        bottom: 30px;
+        right: 30px;
         background-color: #330867;
         color: white;
         border: none;
@@ -320,7 +320,7 @@
             Krishna. Feel the positive energy and tranquility with each mantra.
           </p>
           <div class="audioBtnDiv">
-            <audio controls>
+            <audio class="mantra-audio" controls>
               <source
                 src="./audios/Soothing-Krishna-Chants.mp3"
                 type="audio/mpeg"
@@ -345,7 +345,7 @@
             serenity. Let the divine vibrations guide you through your day.
           </p>
           <div class="audioBtnDiv">
-            <audio controls>
+            <audio class="mantra-audio" controls>
               <source src="./audios/morning-bliss.mp3" type="audio/mpeg" />
               Your browser does not support the audio element.
             </audio>
@@ -362,7 +362,7 @@
             flute.
           </p>
           <div class="audioBtnDiv">
-            <audio controls>
+            <audio class="mantra-audio" controls>
               <source
                 src="./audios/Krishna-Relaxing-Flute.mp3"
                 type="audio/mpeg"
@@ -387,7 +387,7 @@
             positivity and divine blessings. Enhance your spiritual experience.
           </p>
           <div class="audioBtnDiv">
-            <audio controls>
+            <audio class="mantra-audio" controls>
               <source
                 src="./audios/Radiant-Krishna-Arti.mp3"
                 type="audio/mpeg"
@@ -409,7 +409,7 @@
           <h2>Sri Krishna Ashtakam</h2>
           <p>Listen to this powerfull and devine Krishna Ashtakam.</p>
           <div class="audioBtnDiv">
-            <audio controls>
+            <audio class="mantra-audio" controls>
               <source
                 src="./audios/Sri-Krishna-Ashtakam.mp3"
                 type="audio/mpeg"
@@ -483,6 +483,21 @@
       scrollTopBtn.onclick = function () {
         window.scrollTo({ top: 0, behavior: "smooth" }); // Smooth scroll to top
       };
+
+      // Get all audio elements
+        const audioElements = document.querySelectorAll('.mantra-audio');
+
+        audioElements.forEach(audio => {
+            audio.addEventListener('play', () => {
+                // Pause all other audio elements when one is played
+                audioElements.forEach(otherAudio => {
+                    if (otherAudio !== audio) {
+                        otherAudio.pause();
+                    }
+                });
+            });
+        });
+
     </script>
   </body>
 </html>


### PR DESCRIPTION
I have rectified the audio controls problem on the mantra audio page wherein if one audio was played and consecutively other audios were played, then all audios would start playing without any one audio being paused and only one being played.

The problem and the solution videos are provided below -
Problem - 

https://github.com/user-attachments/assets/1d45fd75-1fcb-46ba-92b5-7614d87cbc46


Audio after the solution - 


https://github.com/user-attachments/assets/178cf858-b87e-42e2-9189-accaa4d29e35

Kindly unmute the audios to listen to them.

I have solved the issue #390 using this pull request.
Please merge this PR and also hacktoberfest accepted, gssoc-extd, gssoc-24 and a level tag to this PR.

Thank You @vishal02527 sir.